### PR TITLE
FFI: fetch callbacks: send correct allocation size

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ build:
   services:
     - name: gitlab.cosmian.com:5000/core/kms:2.2.0_ci
       alias: kms_ci
+    - redis:latest
   script:
     - mvn package
   artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [0.10.1]
+### Added
+- Add Findex callbacks implementations for indexes compaction usage
+### Changed
+- Test Findex with Redis callbacks
+### Fixed
+- FFI: fetch callbacks: send correct allocation size in case of insufficient allocated size in order to retry in Rust code
+### Removed
+
+---
 ## [0.10.0]
 ### Added
 - Add `compact` function to FFI to compact indexes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library free software and is available on Maven Central
 <dependency>
     <groupId>com.cosmian</groupId>
     <artifactId>cosmian_java_lib</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.1</version>
 </dependency>
 ```
 
@@ -54,6 +54,7 @@ KMS Server | Java Lib  | GPSW lib  | CoverCrypt lib | Findex
 2.1.0      | 0.7.7     | 1.1.1     | 4.0.0          | 0.2.3
 2.2.0      | 0.8.0     | 2.0.1     | 6.0.1          | 0.4.1
 2.2.0      | 0.9.0     | 2.0.1     | 6.0.1          | 0.5.0
+2.2.0      | 0.10.1    | 2.0.1     | 6.0.1          | 0.6.1
 
 ## Update native libraries
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,8 @@ services:
       - "9998:9998"
     depends_on:
       - db
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cosmian</groupId>
     <artifactId>cosmian_java_lib</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
 
     <name>cosmian_java_lib</name>
     <description>The Cosmian Java Lib provides local encryption/decyption and access to the Cosmian public platform APIs</description>
@@ -100,6 +100,12 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>4.1.1</version>
+            <type>jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/cosmian/jna/findex/Callbacks/FetchChain.java
+++ b/src/main/java/com/cosmian/jna/findex/Callbacks/FetchChain.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.cosmian.jna.FfiException;
+import com.cosmian.jna.findex.Ffi;
 import com.cosmian.jna.findex.FfiWrapper.FetchChainCallback;
 import com.cosmian.jna.findex.FfiWrapper.FetchChainInterface;
 import com.cosmian.jna.findex.Leb128Serializer;
@@ -33,23 +34,14 @@ public class FetchChain implements FetchChainCallback {
         List<byte[]> chainTableUids = Leb128Serializer.deserializeList(uids);
 
         //
-        // Select uid and value in EntryTable
+        // Select uid and value in ChainTable
         //
-        HashMap<byte[], byte[]> values = this.fetch.fetch(chainTableUids);
+        HashMap<byte[], byte[]> uidsAndValues = this.fetch.fetch(chainTableUids);
 
         //
         // Serialize results
         //
-        if (values.size() > 0) {
-            byte[] valuesBytes = Leb128Serializer.serializeHashMap(values);
-
-            output.write(0, valuesBytes, 0, valuesBytes.length);
-            outputSize.setValue(valuesBytes.length);
-        } else {
-            outputSize.setValue(0);
-        }
-
-        return 0;
+        return Ffi.writeOutputPointerAndSize(uidsAndValues, output, outputSize);
     }
 
 }

--- a/src/main/java/com/cosmian/jna/findex/Callbacks/FetchEntry.java
+++ b/src/main/java/com/cosmian/jna/findex/Callbacks/FetchEntry.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.cosmian.jna.FfiException;
+import com.cosmian.jna.findex.Ffi;
 import com.cosmian.jna.findex.FfiWrapper.FetchEntryCallback;
 import com.cosmian.jna.findex.FfiWrapper.FetchEntryInterface;
 import com.cosmian.jna.findex.Leb128Serializer;
@@ -39,15 +40,7 @@ public class FetchEntry implements FetchEntryCallback {
         //
         // Serialize results
         //
-        if (uidsAndValues.size() > 0) {
-            byte[] uidsAndValuesBytes = Leb128Serializer.serializeHashMap(uidsAndValues);
-            output.write(0, uidsAndValuesBytes, 0, uidsAndValuesBytes.length);
-            outputSize.setValue(uidsAndValuesBytes.length);
-        } else {
-            outputSize.setValue(0);
-        }
-
-        return 0;
+        return Ffi.writeOutputPointerAndSize(uidsAndValues, output, outputSize);
     }
 
 }

--- a/src/main/java/com/cosmian/jna/findex/Ffi.java
+++ b/src/main/java/com/cosmian/jna/findex/Ffi.java
@@ -65,6 +65,22 @@ public final class Ffi {
         unwrap(Ffi.INSTANCE.set_error(error_msg));
     }
 
+    public static int writeOutputPointerAndSize(HashMap<byte[], byte[]> uidsAndValues, Pointer output,
+        IntByReference outputSize) {
+        if (uidsAndValues.size() > 0) {
+            byte[] uidsAndValuesBytes = Leb128Serializer.serializeHashMap(uidsAndValues);
+            if (outputSize.getValue() < uidsAndValuesBytes.length) {
+                outputSize.setValue(uidsAndValuesBytes.length);
+                return 1;
+            }
+            outputSize.setValue(uidsAndValuesBytes.length);
+            output.write(0, uidsAndValuesBytes, 0, uidsAndValuesBytes.length);
+        } else {
+            outputSize.setValue(0);
+        }
+        return 0;
+    }
+
     public static void upsert(MasterKeys masterKeys, byte[] label, HashMap<IndexedValue, Word[]> indexedValuesAndWords,
         FetchEntryCallback fetchEntry, UpsertEntryCallback upsertEntry, UpsertChainCallback upsertChain)
         throws FfiException, CosmianException {

--- a/src/test/java/com/cosmian/TestFfiFindex.java
+++ b/src/test/java/com/cosmian/TestFfiFindex.java
@@ -222,10 +222,8 @@ public class TestFfiFindex {
         }
 
         //
-        // Prepare Sqlite tables and users
+        // Prepare Redis tables and users
         //
-        // Sqlite db = new Sqlite();
-        // db.insertUsers(testFindexDataset);
         Redis db = new Redis();
         db.jedis.flushAll();
         db.insertUsers(testFindexDataset);
@@ -303,6 +301,10 @@ public class TestFfiFindex {
         // `EncSym(𝐾value, (ict_uid𝑥𝑤𝑖, 𝐾𝑤𝑖 , 𝑤𝑖))`
         for (int i = 0; i < 100; i++) {
             Ffi.upsert(masterKeys, label, indexedValuesAndWords, db.fetchEntry, db.upsertEntry, db.upsertChain);
+            List<byte[]> indexedValuesList =
+                Ffi.search(masterKeys.getK(), label, new Word[] {new Word("France")}, 0, db.fetchEntry, db.fetchChain);
+            int[] dbUids = indexedValuesBytesListToArray(indexedValuesList);
+            assertArrayEquals(expectedDbUids, dbUids);
         }
     }
 

--- a/src/test/java/com/cosmian/TestFfiFindex.java
+++ b/src/test/java/com/cosmian/TestFfiFindex.java
@@ -180,8 +180,7 @@ public class TestFfiFindex {
 
     @Test
     public void testUpsertAndSearchRedis() throws Exception {
-
-        if (!available(6379)) {
+        if (available(6379)) {
             System.out.println("Ignore test since Redis is down");
             return;
         }

--- a/src/test/java/com/cosmian/findex/Redis.java
+++ b/src/test/java/com/cosmian/findex/Redis.java
@@ -1,0 +1,385 @@
+package com.cosmian.findex;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import com.cosmian.CosmianException;
+import com.cosmian.jna.FfiException;
+import com.cosmian.jna.findex.Location;
+import com.cosmian.jna.findex.Callbacks.FetchAllEntry;
+import com.cosmian.jna.findex.Callbacks.FetchChain;
+import com.cosmian.jna.findex.Callbacks.FetchEntry;
+import com.cosmian.jna.findex.Callbacks.ListRemovedLocations;
+import com.cosmian.jna.findex.Callbacks.UpdateLines;
+import com.cosmian.jna.findex.Callbacks.UpsertChain;
+import com.cosmian.jna.findex.Callbacks.UpsertEntry;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.Transaction;
+
+public class Redis {
+
+    private static final Logger logger = Logger.getLogger(Redis.class.getName());
+
+    public static final String PREFIX_STORAGE = "cosmian";
+
+    public static final int INDEX_TABLE_DATA_STORAGE = 3;
+
+    public static final int INDEX_TABLE_CHAIN_STORAGE = 2;
+
+    public static final int INDEX_TABLE_ENTRY_STORAGE = 1;
+
+    private final JedisPool pool;
+
+    public final Jedis jedis;
+
+    //
+    // Constructors
+    //
+    public Redis(String uri) {
+        this.pool = new JedisPool(uri);
+        this.jedis = this.pool.getResource();
+
+    }
+
+    public Redis() {
+        this.pool = new JedisPool(redisHostname(), redisPort());
+        this.jedis = this.pool.getResource();
+        if (redisPassword() != null)
+            jedis.auth(redisPassword());
+    }
+
+    /**
+     * Instantiate a new Redis Client
+     *
+     * @param hostname the REST Server URL e.g. localhost
+     * @param port Sets a specified port value e.g 6379
+     * @param password the authentication password or token
+     */
+    public Redis(String hostname, int port, String password) {
+        this.pool = new JedisPool(hostname, port);
+        this.jedis = this.pool.getResource();
+        if (!password.isEmpty())
+            jedis.auth(password);
+    }
+
+    public static Redis create(String uri) {
+        return new Redis(uri);
+    }
+
+    static String redisHostname() {
+        String v = System.getenv("REDIS_HOSTNAME");
+        if (v == null) {
+            return "localhost";
+        }
+        return v;
+    }
+
+    static int redisPort() {
+        String v = System.getenv("REDIS_PORT");
+        if (v == null) {
+            return 6379;
+        }
+        return Integer.parseInt(v);
+    }
+
+    static String redisPassword() {
+        String v = System.getenv("REDIS_PASSWORD");
+        return v;
+    }
+
+    //
+    // Very basic redis functions
+    public byte[] get(byte[] key) throws CosmianException {
+        return this.jedis.get(key);
+    }
+
+    public long del(byte[] key) throws CosmianException {
+        return this.jedis.del(key);
+    }
+
+    public byte[] set(byte[] key, byte[] value) throws CosmianException {
+        return this.jedis.getSet(key, value);
+    }
+
+    //
+    // Declare all callbacks
+    //
+    public FetchEntry fetchEntry = new FetchEntry(new com.cosmian.jna.findex.FfiWrapper.FetchEntryInterface() {
+        @Override
+        public HashMap<byte[], byte[]> fetch(List<byte[]> uids) throws FfiException {
+            try {
+                return getEntries(uids, INDEX_TABLE_ENTRY_STORAGE);
+            } catch (CosmianException e) {
+                throw new FfiException("Failed fetch entry: " + e.toString());
+            }
+        }
+    });
+
+    public FetchChain fetchChain = new FetchChain(new com.cosmian.jna.findex.FfiWrapper.FetchChainInterface() {
+        @Override
+        public HashMap<byte[], byte[]> fetch(List<byte[]> uids) throws FfiException {
+            try {
+                return getEntries(uids, INDEX_TABLE_CHAIN_STORAGE);
+            } catch (CosmianException e) {
+                throw new FfiException("Failed chain upsert: " + e.toString());
+            }
+        }
+    });
+
+    public FetchAllEntry fetchAllEntry =
+        new FetchAllEntry(new com.cosmian.jna.findex.FfiWrapper.FetchAllEntryInterface() {
+            @Override
+            public HashMap<byte[], byte[]> fetch() throws FfiException {
+                try {
+                    return getAllKeysAndValues(INDEX_TABLE_ENTRY_STORAGE);
+                } catch (CosmianException e) {
+                    throw new FfiException("Failed fetch all entry: " + e.toString());
+                }
+            }
+        });
+
+    public UpsertEntry upsertEntry = new UpsertEntry(new com.cosmian.jna.findex.FfiWrapper.UpsertEntryInterface() {
+        @Override
+        public void upsert(HashMap<byte[], byte[]> uidsAndValues) throws FfiException {
+            try {
+                setEntries(uidsAndValues);
+            } catch (CosmianException e) {
+                throw new FfiException("Failed entry upsert: " + e.toString());
+            }
+        }
+    });
+
+    public UpsertChain upsertChain = new UpsertChain(new com.cosmian.jna.findex.FfiWrapper.UpsertChainInterface() {
+        @Override
+        public void upsert(HashMap<byte[], byte[]> uidsAndValues) throws FfiException {
+            try {
+                setChains(uidsAndValues);
+            } catch (CosmianException e) {
+                throw new FfiException("Failed chain upsert: " + e.toString());
+            }
+        }
+    });
+
+    /// Update the database with the new values. This function should:
+    /// - remove all the Index Entry Table
+    /// - add `new_encrypted_entry_table_items` to the Index Entry Table
+    /// - remove `removed_chain_table_uids` from the Index Chain Table
+    /// - add `new_encrypted_chain_table_items` to the Index Chain Table
+    ///
+    /// The order of these operation is not important but have some implications:
+    ///
+    /// ### Option 1
+    ///
+    /// Keep the database small but prevent using the index during the `update_lines`.
+    ///
+    /// 1. remove all the Index Entry Table
+    /// 2. add `new_encrypted_entry_table_items` to the Index Entry Table
+    /// 3. remove `removed_chain_table_uids` from the Index Chain Table
+    /// 4. add `new_encrypted_chain_table_items` to the Index Chain Table
+    ///
+    /// ### Option 2
+    ///
+    /// During a small duration, the index tables are much bigger but users can continue
+    /// using the index during the `update_lines`.
+    ///
+    /// 1. save all UIDs from the current Index Entry Table
+    /// 2. add `new_encrypted_entry_table_items` to the Index Entry Table
+    /// 3. add `new_encrypted_chain_table_items` to the Index Chain Table
+    /// 4. publish new label to users
+    /// 5. remove old lines from the Index Entry Table (using the saved UIDs in 1.)
+    /// 6. remove `removed_chain_table_uids` from the Index Chain Table
+    public UpdateLines updateLines = new UpdateLines(new com.cosmian.jna.findex.FfiWrapper.UpdateLinesInterface() {
+        @Override
+        public void update(List<byte[]> removedChains, HashMap<byte[], byte[]> newEntries,
+            HashMap<byte[], byte[]> newChains) throws FfiException {
+            try {
+                delAllEntries(INDEX_TABLE_ENTRY_STORAGE);
+                setEntries(newEntries);
+                setChains(newChains);
+                delEntries(removedChains, INDEX_TABLE_CHAIN_STORAGE);
+            } catch (CosmianException e) {
+                throw new FfiException("Failed update lines: " + e.toString());
+            }
+        }
+    });
+
+    public ListRemovedLocations listRemovedLocations =
+        new ListRemovedLocations(new com.cosmian.jna.findex.FfiWrapper.ListRemovedLocationsInterface() {
+            @Override
+            public List<Location> list(List<Location> locations) throws FfiException {
+                List<Integer> ids =
+                    locations.stream().map((Location location) -> ByteBuffer.wrap(location.getBytes()).getInt())
+                        .collect(Collectors.toList());
+
+                try {
+                    return listRemovedIds(ids).stream()
+                        .map((Integer id) -> new Location(ByteBuffer.allocate(32).putInt(id).array()))
+                        .collect(Collectors.toList());
+                } catch (CosmianException e) {
+                    throw new FfiException("Failed update lines: " + e.toString());
+                }
+
+            }
+        });
+
+    public List<Integer> listRemovedIds(List<Integer> ids) throws CosmianException {
+        HashSet<Integer> removedIds = new HashSet<>(ids);
+        for (Integer id : ids) {
+            byte[] keySuffix = ByteBuffer.allocate(4).putInt(id).array();
+            byte[] value = getDataEntry(keySuffix);
+            if (value != null) {
+                removedIds.remove(id);
+            }
+        }
+        return new LinkedList<>(removedIds);
+    }
+
+    /**
+     * Format Redis key as NUMBER:HEX_UID
+     *
+     * @param prefix table prefix (can be 1, 2 or 3)
+     * @param number the index of the table
+     * @param uid which is the UID of
+     * @return key as prefix|number on 4 bytes|uid
+     */
+    public static byte[] key(String prefix, int number, byte[] uid) {
+        byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+        byte[] numberBytes = ByteBuffer.allocate(4).putInt(number).array();
+        byte[] result = Arrays.copyOf(prefixBytes, prefixBytes.length + numberBytes.length + uid.length);
+        System.arraycopy(numberBytes, 0, result, prefixBytes.length, numberBytes.length);
+        System.arraycopy(uid, 0, result, prefixBytes.length + numberBytes.length, uid.length);
+        return result;
+    }
+
+    public HashMap<byte[], byte[]> getEntries(List<byte[]> uids, int redisPrefix) throws CosmianException {
+        Transaction tx = this.jedis.multi();
+        List<byte[]> keys = new ArrayList<>();
+        for (byte[] uid : uids) {
+            byte[] key = key(PREFIX_STORAGE, redisPrefix, uid);
+            keys.add(key);
+        }
+        byte[][] keysArray = keys.toArray(new byte[0][]);
+        Response<List<byte[]>> mgetResults = tx.mget(keysArray);
+        tx.exec();
+
+        HashMap<byte[], byte[]> keysAndValues = new HashMap<>();
+        for (int i = 0; i < mgetResults.get().size(); i++) {
+            byte[] key = uids.get(i);
+            byte[] value = mgetResults.get().get(i);
+            if (value != null) {
+                keysAndValues.put(key, value);
+            }
+        }
+        return keysAndValues;
+    }
+
+    public void setEntries(HashMap<byte[], byte[]> uidsAndValues) throws CosmianException {
+        Transaction tx = this.jedis.multi();
+        for (Entry<byte[], byte[]> entry : uidsAndValues.entrySet()) {
+            byte[] key = key(PREFIX_STORAGE, INDEX_TABLE_ENTRY_STORAGE, entry.getKey());
+            tx.getSet(key, entry.getValue());
+        }
+        tx.exec();
+    }
+
+    public void setChains(HashMap<byte[], byte[]> uidsAndValues) throws CosmianException {
+        Transaction tx = this.jedis.multi();
+        for (Entry<byte[], byte[]> entry : uidsAndValues.entrySet()) {
+            byte[] key = key(PREFIX_STORAGE, INDEX_TABLE_CHAIN_STORAGE, entry.getKey());
+            tx.getSet(key, entry.getValue());
+        }
+        tx.exec();
+    }
+
+    public byte[] getDataEntry(byte[] uid) throws CosmianException {
+        byte[] key = key(PREFIX_STORAGE, INDEX_TABLE_DATA_STORAGE, uid);
+        return get(key);
+    }
+
+    public byte[] setDataEntry(byte[] uid, byte[] value) throws CosmianException {
+        byte[] key = key(PREFIX_STORAGE, INDEX_TABLE_DATA_STORAGE, uid);
+        return set(key, value);
+    }
+
+    public long delDataEntry(byte[] uid) throws CosmianException {
+        byte[] key = key(PREFIX_STORAGE, INDEX_TABLE_DATA_STORAGE, uid);
+        return del(key);
+    }
+
+    public List<byte[]> getAllKeys(int redisIndex) throws CosmianException {
+        List<byte[]> keys = new ArrayList<>();
+        Transaction tx = this.jedis.multi();
+        byte[] key = key(PREFIX_STORAGE, redisIndex, "*".getBytes());
+        Response<Set<byte[]>> responses = tx.keys(key);
+        tx.exec();
+        if (responses.get() == null) {
+            throw new CosmianException("Failed to get Redis items");
+        }
+        for (byte[] keyIter : responses.get()) {
+            keys.add(keyIter);
+        }
+        return keys;
+    }
+
+    public HashMap<byte[], byte[]> getAllKeysAndValues(int redisIndex) throws CosmianException {
+        List<byte[]> keys = getAllKeys(redisIndex);
+
+        // Get all values now
+        byte[][] keysArray = keys.toArray(new byte[0][]);
+        Transaction tx2 = this.jedis.multi();
+        Response<List<byte[]>> mgetResults = tx2.mget(keysArray);
+        tx2.exec();
+
+        HashMap<byte[], byte[]> keysAndValues = new HashMap<>();
+        for (int i = 0; i < mgetResults.get().size(); i++) {
+            // byte[] key = uids.get(i);
+            byte[] value = mgetResults.get().get(i);
+            if (value != null) {
+                keysAndValues.put(keys.get(i), value);
+            }
+        }
+        return keysAndValues;
+    }
+
+    public void delEntries(List<byte[]> uids, int redisPrefix) throws CosmianException {
+        for (byte[] uid : uids) {
+            byte[] key = key(PREFIX_STORAGE, redisPrefix, uid);
+            this.jedis.del(key);
+        }
+    }
+
+    public void delAllEntries(int redisPrefix) throws CosmianException {
+        List<byte[]> keys = getAllKeys(redisPrefix);
+        for (byte[] key : keys) {
+            this.jedis.del(key);
+        }
+    }
+
+    public void insertUsers(UsersDataset[] testFindexDataset) throws CosmianException {
+        for (UsersDataset user : testFindexDataset) {
+            String json = user.toString();
+            byte[] keySuffix = ByteBuffer.allocate(4).putInt(user.id).array();
+            setDataEntry(keySuffix, json.getBytes());
+        }
+    }
+
+    public long deleteUser(int uid) throws CosmianException {
+        byte[] keySuffix = ByteBuffer.allocate(4).putInt(uid).array();
+        byte[] key = key(PREFIX_STORAGE, INDEX_TABLE_DATA_STORAGE, keySuffix);
+        return del(key);
+    }
+
+}

--- a/src/test/java/com/cosmian/findex/Sqlite.java
+++ b/src/test/java/com/cosmian/findex/Sqlite.java
@@ -1,5 +1,6 @@
 package com.cosmian.findex;
 
+import java.nio.ByteBuffer;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -11,10 +12,114 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import com.cosmian.jna.FfiException;
+import com.cosmian.jna.findex.Location;
+import com.cosmian.jna.findex.Callbacks.FetchAllEntry;
+import com.cosmian.jna.findex.Callbacks.FetchChain;
+import com.cosmian.jna.findex.Callbacks.FetchEntry;
+import com.cosmian.jna.findex.Callbacks.ListRemovedLocations;
+import com.cosmian.jna.findex.Callbacks.UpdateLines;
+import com.cosmian.jna.findex.Callbacks.UpsertChain;
+import com.cosmian.jna.findex.Callbacks.UpsertEntry;
 
 public class Sqlite {
 
     private Connection connection;
+
+    //
+    // Declare all Findex callbacks
+    //
+    public FetchEntry fetchEntry = new FetchEntry(new com.cosmian.jna.findex.FfiWrapper.FetchEntryInterface() {
+        @Override
+        public HashMap<byte[], byte[]> fetch(List<byte[]> uids) throws FfiException {
+            try {
+                return fetchEntryTableItems(uids);
+            } catch (SQLException e) {
+                throw new FfiException("Failed fetch entry: " + e.toString());
+            }
+        }
+    });
+
+    public FetchAllEntry fetchAllEntry = new FetchAllEntry(new com.cosmian.jna.findex.FfiWrapper.FetchAllEntryInterface() {
+        @Override
+        public HashMap<byte[], byte[]> fetch() throws FfiException {
+            try {
+                return fetchAllEntryTableItems();
+            } catch (SQLException e) {
+                throw new FfiException("Failed fetch all entry: " + e.toString());
+            }
+        }
+    });
+
+    public FetchChain fetchChain = new FetchChain(new com.cosmian.jna.findex.FfiWrapper.FetchChainInterface() {
+        @Override
+        public HashMap<byte[], byte[]> fetch(List<byte[]> uids) throws FfiException {
+            try {
+                return fetchChainTableItems(uids);
+            } catch (SQLException e) {
+                throw new FfiException("Failed fetch chain: " + e.toString());
+            }
+        }
+    });
+
+    public UpsertEntry upsertEntry = new UpsertEntry(new com.cosmian.jna.findex.FfiWrapper.UpsertEntryInterface() {
+        @Override
+        public void upsert(HashMap<byte[], byte[]> uidsAndValues) throws FfiException {
+            try {
+                databaseUpsert(uidsAndValues, "entry_table");
+            } catch (SQLException e) {
+                throw new FfiException("Failed entry upsert: " + e.toString());
+            }
+        }
+    });
+
+    public UpsertChain upsertChain = new UpsertChain(new com.cosmian.jna.findex.FfiWrapper.UpsertChainInterface() {
+        @Override
+        public void upsert(HashMap<byte[], byte[]> uidsAndValues) throws FfiException {
+            try {
+                databaseUpsert(uidsAndValues, "chain_table");
+            } catch (SQLException e) {
+                throw new FfiException("Failed chain upsert: " + e.toString());
+            }
+        }
+    });
+
+    public UpdateLines updateLines = new UpdateLines(new com.cosmian.jna.findex.FfiWrapper.UpdateLinesInterface() {
+        @Override
+        public void update(List<byte[]> removedChains, HashMap<byte[], byte[]> newEntries,
+            HashMap<byte[], byte[]> newChains) throws FfiException {
+            try {
+                databaseTruncate("entry_table");
+                databaseUpsert(newEntries, "entry_table");
+                databaseUpsert(newChains, "chain_table");
+                databaseRemove(removedChains, "chain_table");
+            } catch (SQLException e) {
+                throw new FfiException("Failed update lines: " + e.toString());
+            }
+        }
+    });
+
+    public ListRemovedLocations listRemovedLocations =
+        new ListRemovedLocations(new com.cosmian.jna.findex.FfiWrapper.ListRemovedLocationsInterface() {
+            @Override
+            public List<Location> list(List<Location> locations) throws FfiException {
+                List<Integer> ids =
+                    locations.stream().map((Location location) -> ByteBuffer.wrap(location.getBytes()).getInt())
+                        .collect(Collectors.toList());
+
+                try {
+                    return listRemovedIds("users", ids).stream()
+                        .map((Integer id) -> new Location(ByteBuffer.allocate(32).putInt(id).array()))
+                        .collect(Collectors.toList());
+                } catch (SQLException e) {
+                    throw new FfiException("Failed update lines: " + e.toString());
+                }
+
+            }
+        });
+
 
     public Sqlite() throws SQLException {
         this.connection = DriverManager.getConnection("jdbc:sqlite::memory:");
@@ -114,9 +219,9 @@ public class Sqlite {
             pstmt.setBytes(2, entry.getValue());
             pstmt.addBatch();
         }
-        int[] result = pstmt.executeBatch();
+        /* int[] result = */ pstmt.executeBatch();
         this.connection.commit();
-        System.out.println("The number of rows in " + tableName + " inserted: " + result.length);
+        // System.out.println("The number of rows in " + tableName + " inserted: " + result.length);
     }
 
     public void databaseRemove(List<byte[]> uids, String tableName) throws SQLException {

--- a/src/test/java/com/cosmian/findex/UsersDataset.java
+++ b/src/test/java/com/cosmian/findex/UsersDataset.java
@@ -43,6 +43,11 @@ public class UsersDataset {
             new Word(this.security)};
     }
 
+    public String toString() {
+        return this.firstName + this.lastName + this.phone + this.email + this.country + this.region
+            + this.employeeNumber + this.security;
+    }
+
     /**
      * This method is mostly used for local tests and serialization.
      *

--- a/src/test/resources/linux-x86-64/update_native_libraries.sh
+++ b/src/test/resources/linux-x86-64/update_native_libraries.sh
@@ -26,7 +26,7 @@ build_native_library() {
 
 build_native_library git@github.com:Cosmian abe_gpsw v2.0.1 libabe_gpsw.so
 build_native_library git@github.com:Cosmian cover_crypt v6.0.1 libcover_crypt.so
-build_native_library git@gitlab.cosmian.com:core findex v0.5.0 libcosmian_findex.so
+build_native_library git@gitlab.cosmian.com:core findex v0.6.1 libcosmian_findex.so
 
 # Since docker user is root, restore local permissions to current user
 sudo chown -R "$(whoami)" .


### PR DESCRIPTION
---
## [0.10.1]
### Added
- Add Findex callbacks implementations for indexes compaction usage
### Changed
- Test Findex with Redis callbacks
### Fixed
- FFI: fetch callbacks: send correct allocation size in case of insufficient allocated size in order to retry in Rust code
### Removed