### PR TITLE
Bump/kms version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
 build:
   stage: build
   services:
-    - name: gitlab.cosmian.com:5000/core/kms:2.3.0_ci
+    - name: gitlab.cosmian.com:5000/core/kms:${KMS_VERSION}_ci
       alias: kms_ci
     - redis:latest
   script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [1.11.1] - 2022-10-14
+### Added
+### Changed
+- Update license
+- CI: use KMS version from Gitlab variable
+### Fixed
+### Removed
+
+---
 ## [1.11.0] - 2022-10-13
 ### Added
 - Native libraries for Windows and MacOs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This library free software and is available on Maven Central
 <dependency>
     <groupId>com.cosmian</groupId>
     <artifactId>cloudproof_java</artifactId>
-    <version>1.11.0</version>
+    <version>1.11.1</version>
 </dependency>
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - PGDATA=/tmp/postgres2
   kms:
     container_name: kms
-    image: gitlab.cosmian.com:5000/core/kms:2.3.0_ci
+    image: gitlab.cosmian.com:5000/core/kms:2.3.1_ci
     environment:
       - KMS_HOSTNAME=0.0.0.0
       - KMS_PUBLIC_PATH=/tmp

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cosmian</groupId>
     <artifactId>cloudproof_java</artifactId>
-    <version>1.11.0</version>
+    <version>1.11.1</version>
 
     <name>cloudproof_java</name>
     <description>The Cloudproof Java Lib secures data repositories in the cloud with attributes-based access control encryption and encrypted search</description>


### PR DESCRIPTION
---
## [1.11.1] - 2022-10-14
### Added
### Changed
- Update license
- CI: use KMS version from Gitlab variable
### Fixed
### Removed