### PR TITLE
feat: allocate FFI output from Rust

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,12 +49,7 @@ jobs:
   build_in_docker:
     services:
       kms:
-        image: cosmian/kms:4.3.3
-        env:
-          COSMIAN_SERVER_URL: http://localhost:9998
-          KMS_PUBLIC_PATH: /tmp
-          KMS_PRIVATE_PATH: /tmp
-          KMS_SHARED_PATH: /tmp
+        image: ghcr.io/cosmian/kms:4.3.3
         ports:
           - 9998:9998
       findex_cloud:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -162,6 +162,7 @@ jobs:
       branch: develop
       target: wasm32-unknown-unknown
       kms-version: 4.3.3
+      findex-cloud-version: 0.1.0
       copy_fresh_build: false
       copy_regression_files: |
         cp ./cloudproof_java/non_regression_vector.json tests/data/cover_crypt/non_regression/java_non_regression_vector.json

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -92,6 +92,11 @@ jobs:
       - run: yum -y install java-1.8.0-openjdk maven python3 python3-pip
       - run: python3 scripts/get_native_libraries.py
 
+      - name: Display ldd version
+        run: |
+          ldd --version
+          ldd src/main/resources/linux-x86-64/libcloudproof.so
+
       - name: Build with Maven
         run: mvn compile
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,7 @@ jobs:
   build_in_docker:
     services:
       kms:
-        image: ghcr.io/cosmian/kms:4.3.3
+        image: ghcr.io/cosmian/kms:4.4.3
         ports:
           - 9998:9998
       findex_cloud:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -161,7 +161,7 @@ jobs:
     with:
       branch: develop
       target: wasm32-unknown-unknown
-      kms-version: 4.3.3
+      kms-version: 4.4.3
       findex-cloud-version: 0.1.0
       copy_fresh_build: false
       copy_regression_files: |
@@ -174,7 +174,7 @@ jobs:
     with:
       branch: develop
       target: x86_64-unknown-linux-gnu
-      kms-version: 4.3.3
+      kms-version: 4.4.3
       copy_fresh_build: false
       copy_regression_files: |
         cp ./cloudproof_java/non_regression_vector.json tests/data/cover_crypt/non_regression/java_non_regression_vector.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,7 @@ services:
       - PGDATA=/tmp/postgres2
   kms:
     container_name: kms
-    image: cosmian/kms:4.3.3
-    environment:
-      - KMS_HOSTNAME=0.0.0.0
-      - KMS_PUBLIC_PATH=/tmp
-      - KMS_PRIVATE_PATH=/tmp
-      - KMS_SHARED_PATH=/tmp
+    image: ghcr.io/cosmian/kms:4.4.3
     ports:
       - 9998:9998
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,8 @@ services:
     image: redis:latest
     ports:
       - 6379:6379
+
+  findex_cloud:
+    image: ghcr.io/cosmian/findex_cloud:0.1.0
+    ports:
+      - 8080:8080

--- a/scripts/get_native_libraries.py
+++ b/scripts/get_native_libraries.py
@@ -62,6 +62,6 @@ def download_native_libraries(version: str) -> bool:
 
 
 if __name__ == '__main__':
-    ret = download_native_libraries('v2.0.1')
+    ret = download_native_libraries('v2.2.0')
     if ret is False and getenv('GITHUB_ACTIONS'):
-        download_native_libraries('last_build/release/v2.0.1')
+        download_native_libraries('last_build/feature/findex_5_0_0')

--- a/scripts/get_native_libraries.py
+++ b/scripts/get_native_libraries.py
@@ -64,4 +64,4 @@ def download_native_libraries(version: str) -> bool:
 if __name__ == '__main__':
     ret = download_native_libraries('v2.2.0')
     if ret is False and getenv('GITHUB_ACTIONS'):
-        download_native_libraries('last_build/feature/findex_5_0_0')
+        download_native_libraries('last_build/feature/ffi_allocate_from_rust')

--- a/src/main/java/com/cosmian/jna/findex/Findex.java
+++ b/src/main/java/com/cosmian/jna/findex/Findex.java
@@ -4,7 +4,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.cosmian.jna.findex.ffi.FindexUserCallbacks.SearchProgress;
 import com.cosmian.jna.findex.ffi.Progress;
@@ -34,19 +33,14 @@ public final class Findex extends FindexBase {
             keyPointer.write(0, key, 0, key.length);
             labelPointer.write(0, label, 0, label.length);
 
-            long start = System.currentTimeMillis();
-
             //
             // Prepare outputs
             //
             // Allocate the amount of memory needed to store all upserted keywords.
-            Set<Keyword> upsertedKeywords = additions.values().stream().flatMap(set -> set.stream()).collect(Collectors.toSet());
-            upsertedKeywords.addAll(deletions.values().stream().flatMap(set -> set.stream()).collect(Collectors.toSet()));
-            Integer memoryToAllocate = upsertedKeywords.stream().map(keyword -> keyword.getBytes().length + 8).reduce(Integer::sum).get();
-            byte[] newKeywordsBuffer = new byte[memoryToAllocate];
+            byte[] newKeywordsBuffer = new byte[0];
             IntByReference newKeywordsBufferSize = new IntByReference(newKeywordsBuffer.length);
-
-            unwrap(INSTANCE.h_upsert(newKeywordsBuffer, newKeywordsBufferSize,
+            long start = System.currentTimeMillis();
+            int ffiCode = INSTANCE.h_upsert(newKeywordsBuffer, newKeywordsBufferSize,
                                      keyPointer, key.length,
                                      labelPointer, label.length,
                                      indexedValuesToJson(additions),
@@ -54,8 +48,24 @@ public final class Findex extends FindexBase {
                                      entryTableNumber,
                                      db.fetchEntryCallback(),
                                      db.upsertEntryCallback(),
-                                     db.upsertChainCallback()),
-                    start);
+                                     db.upsertChainCallback());
+            FindexCallbackException.rethrowOnErrorCode(ffiCode, start, System.currentTimeMillis());
+
+            if (ffiCode != 0) {
+                // Retry with correct allocated size
+                newKeywordsBuffer = new byte[newKeywordsBufferSize.getValue()];
+                long startRetry = System.currentTimeMillis();
+                unwrap(INSTANCE.h_upsert(newKeywordsBuffer, newKeywordsBufferSize,
+                                         keyPointer, key.length,
+                                         labelPointer, label.length,
+                                         indexedValuesToJson(additions),
+                                         indexedValuesToJson(deletions),
+                                         entryTableNumber,
+                                         db.fetchEntryCallback(),
+                                         db.upsertEntryCallback(),
+                                         db.upsertChainCallback())
+                        , startRetry);
+            }
 
             byte[] newKeywordsBytes = Arrays.copyOfRange(newKeywordsBuffer, 0, newKeywordsBufferSize.getValue());
 

--- a/src/main/java/com/cosmian/jna/findex/Findex.java
+++ b/src/main/java/com/cosmian/jna/findex/Findex.java
@@ -68,7 +68,6 @@ public final class Findex extends FindexBase {
             }
 
             byte[] newKeywordsBytes = Arrays.copyOfRange(newKeywordsBuffer, 0, newKeywordsBufferSize.getValue());
-
             return  new Leb128Reader(newKeywordsBytes).readObject(UpsertResults.class);
         }
     }

--- a/src/main/java/com/cosmian/jna/findex/Findex.java
+++ b/src/main/java/com/cosmian/jna/findex/Findex.java
@@ -51,7 +51,7 @@ public final class Findex extends FindexBase {
                                      db.upsertChainCallback());
             FindexCallbackException.rethrowOnErrorCode(ffiCode, start, System.currentTimeMillis());
 
-            if (ffiCode != 0) {
+            if (ffiCode == 1) {
                 // Retry with correct allocated size
                 newKeywordsBuffer = new byte[newKeywordsBufferSize.getValue()];
                 long startRetry = System.currentTimeMillis();

--- a/src/main/java/com/cosmian/jna/findex/Findex.java
+++ b/src/main/java/com/cosmian/jna/findex/Findex.java
@@ -15,6 +15,8 @@ import com.cosmian.jna.findex.structs.IndexedValue;
 import com.cosmian.jna.findex.structs.Keyword;
 import com.cosmian.utils.CloudproofException;
 import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 
 public final class Findex extends FindexBase {
@@ -33,41 +35,24 @@ public final class Findex extends FindexBase {
             keyPointer.write(0, key, 0, key.length);
             labelPointer.write(0, label, 0, label.length);
 
-            // Do not allocate memory. The Rust FFI function will directly
-            // return after setting newKeywordsBufferSize to an upper bound on
-            // the amount of memory to allocate.
-            byte[] newKeywordsBuffer = new byte[0];
-            IntByReference newKeywordsBufferSize = new IntByReference();
+            // Allocate the amount of memory needed to store a pointer.
+            Memory newKeywordsBuffer = new Memory(8);
+            IntByReference newKeywordsBufferSize = new IntByReference(0);
 
             long start = System.currentTimeMillis();
-            int ffiCode = INSTANCE.h_upsert(newKeywordsBuffer, newKeywordsBufferSize,
-                                            keyPointer, key.length,
-                                            labelPointer, label.length,
-                                            indexedValuesToJson(additions),
-                                            indexedValuesToJson(deletions),
-                                            entryTableNumber,
-                                            db.fetchEntryCallback(),
-                                            db.upsertEntryCallback(),
-                                            db.upsertChainCallback());
+            unwrap(INSTANCE.h_upsert(newKeywordsBuffer, newKeywordsBufferSize,
+                                     keyPointer, key.length,
+                                     labelPointer, label.length,
+                                     indexedValuesToJson(additions),
+                                     indexedValuesToJson(deletions),
+                                     entryTableNumber,
+                                     db.fetchEntryCallback(),
+                                     db.upsertEntryCallback(),
+                                     db.upsertChainCallback()),
+                    start);
 
-            FindexCallbackException.rethrowOnErrorCode(ffiCode, start, System.currentTimeMillis());
-
-            if (ffiCode == 1) {
-                newKeywordsBuffer = new byte[newKeywordsBufferSize.getValue()];
-                unwrap(INSTANCE.h_upsert(newKeywordsBuffer, newKeywordsBufferSize,
-                                         keyPointer, key.length,
-                                         labelPointer, label.length,
-                                         indexedValuesToJson(additions),
-                                         indexedValuesToJson(deletions),
-                                         entryTableNumber,
-                                         db.fetchEntryCallback(),
-                                         db.upsertEntryCallback(),
-                                         db.upsertChainCallback()));
-            } else if (ffiCode != 0) {
-                unwrap(ffiCode);
-            }
-
-            byte[] newKeywordsBytes = Arrays.copyOfRange(newKeywordsBuffer, 0, newKeywordsBufferSize.getValue());
+            byte[] newKeywordsBytes = newKeywordsBuffer.getPointer(0).getByteArray(0, newKeywordsBufferSize.getValue());
+            Native.free(Pointer.nativeValue(newKeywordsBuffer.getPointer(0)));
             return  new Leb128Reader(newKeywordsBytes).readObject(UpsertResults.class);
         }
     }

--- a/src/main/java/com/cosmian/jna/findex/FindexCloud.java
+++ b/src/main/java/com/cosmian/jna/findex/FindexCloud.java
@@ -12,6 +12,8 @@ import com.cosmian.jna.findex.structs.IndexedValue;
 import com.cosmian.jna.findex.structs.Keyword;
 import com.cosmian.utils.CloudproofException;
 import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
 
 public final class FindexCloud extends FindexBase {
@@ -63,34 +65,21 @@ public final class FindexCloud extends FindexBase {
             final Memory labelPointer = new Memory(label.length)) {
             labelPointer.write(0, label, 0, label.length);
 
-            // Do not allocate memory. The Rust FFI function will directly
-            // return after setting newKeywordsBufferSize to an upper bound on
-            // the amount of memory to allocate.
-            byte[] newKeywordsBuffer = new byte[0];
-            IntByReference newKeywordsBufferSize = new IntByReference();
+            // Allocate the amount of memory needed to store a pointer.
+            Memory newKeywordsBuffer = new Memory(8);
+            IntByReference newKeywordsBufferSize = new IntByReference(0);
 
             long start = System.currentTimeMillis();
-            int ffiCode = INSTANCE.h_upsert_cloud(newKeywordsBuffer, newKeywordsBufferSize,
-                                                  token,
-                                                  labelPointer, label.length,
-                                                  indexedValuesToJson(additions),
-                                                  indexedValuesToJson(deletions),
-                                                  baseUrl);
-            FindexCallbackException.rethrowOnErrorCode(ffiCode, start, System.currentTimeMillis());
+            unwrap(INSTANCE.h_upsert_cloud(newKeywordsBuffer, newKeywordsBufferSize,
+                                           token,
+                                           labelPointer, label.length,
+                                           indexedValuesToJson(additions),
+                                           indexedValuesToJson(deletions),
+                                           baseUrl),
+                    start);
 
-            if (ffiCode == 1) {
-                newKeywordsBuffer = new byte[newKeywordsBufferSize.getValue()];
-                unwrap(INSTANCE.h_upsert_cloud(newKeywordsBuffer, newKeywordsBufferSize,
-                                               token,
-                                               labelPointer, label.length,
-                                               indexedValuesToJson(additions),
-                                               indexedValuesToJson(deletions),
-                                               baseUrl));
-            } else if (ffiCode != 0) {
-                unwrap(ffiCode);
-            }
-
-            byte[] newKeywordsBytes = Arrays.copyOfRange(newKeywordsBuffer, 0, newKeywordsBufferSize.getValue());
+            byte[] newKeywordsBytes = newKeywordsBuffer.getPointer(0).getByteArray(0, newKeywordsBufferSize.getValue());
+            Native.free(Pointer.nativeValue(newKeywordsBuffer.getPointer(0)));
             return  new Leb128Reader(newKeywordsBytes).readObject(UpsertResults.class);
         }
     }

--- a/src/main/java/com/cosmian/jna/findex/FindexCloud.java
+++ b/src/main/java/com/cosmian/jna/findex/FindexCloud.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.cosmian.jna.findex.ffi.SearchResults;
+import com.cosmian.jna.findex.ffi.UpsertResults;
 import com.cosmian.jna.findex.serde.Leb128Reader;
 import com.cosmian.jna.findex.structs.IndexedValue;
 import com.cosmian.jna.findex.structs.Keyword;
@@ -51,12 +52,11 @@ public final class FindexCloud extends FindexBase {
         }
     }
 
-    public static void upsert(
-                              String token,
-                              byte[] label,
-                              Map<IndexedValue, Set<Keyword>> additions,
-                              Map<IndexedValue, Set<Keyword>> deletions,
-                              String baseUrl)
+    public static UpsertResults upsert(String token,
+                                       byte[] label,
+                                       Map<IndexedValue, Set<Keyword>> additions,
+                                       Map<IndexedValue, Set<Keyword>> deletions,
+                                       String baseUrl)
         throws CloudproofException {
 
         try (
@@ -64,27 +64,46 @@ public final class FindexCloud extends FindexBase {
             labelPointer.write(0, label, 0, label.length);
 
             // Indexes creation + insertion/update
-            unwrap(INSTANCE.h_upsert_cloud(
-                token,
-                labelPointer, label.length,
-                indexedValuesToJson(additions),
-                indexedValuesToJson(deletions),
-                baseUrl));
+            byte[] newKeywordsBuffer = new byte[0];
+            IntByReference newKeywordsBufferSize = new IntByReference(newKeywordsBuffer.length);
+            long start = System.currentTimeMillis();
+            int ffiCode = INSTANCE.h_upsert_cloud(newKeywordsBuffer, newKeywordsBufferSize,
+                                                  token,
+                                                  labelPointer, label.length,
+                                                  indexedValuesToJson(additions),
+                                                  indexedValuesToJson(deletions),
+                                                  baseUrl);
+            FindexCallbackException.rethrowOnErrorCode(ffiCode, start, System.currentTimeMillis());
+
+            if (ffiCode != 0) {
+                // Retry with correct allocated size
+                newKeywordsBuffer = new byte[newKeywordsBufferSize.getValue()];
+                long startRetry = System.currentTimeMillis();
+                unwrap(INSTANCE.h_upsert_cloud(newKeywordsBuffer, newKeywordsBufferSize,
+                                               token,
+                                               labelPointer, label.length,
+                                               indexedValuesToJson(additions),
+                                               indexedValuesToJson(deletions),
+                                               baseUrl),
+                        startRetry);
+            }
+
+            byte[] newKeywordsBytes = Arrays.copyOfRange(newKeywordsBuffer, 0, newKeywordsBufferSize.getValue());
+            return  new Leb128Reader(newKeywordsBytes).readObject(UpsertResults.class);
         }
     }
 
-    public static void upsert(IndexRequest request)
+    public static UpsertResults upsert(IndexRequest request)
         throws CloudproofException {
-        upsert(request.token, request.label, request.additions, request.deletions, request.baseUrl);
+        return upsert(request.token, request.label, request.additions, request.deletions, request.baseUrl);
     }
 
-    public static void upsert(
-                              String token,
-                              byte[] label,
-                              Map<IndexedValue, Set<Keyword>> additions,
-                              Map<IndexedValue, Set<Keyword>> deletions)
+    public static UpsertResults upsert(String token,
+                                       byte[] label,
+                                       Map<IndexedValue, Set<Keyword>> additions,
+                                       Map<IndexedValue, Set<Keyword>> deletions)
         throws CloudproofException {
-        upsert(token, label, additions, deletions, null);
+        return upsert(token, label, additions, deletions, null);
     }
 
     public static SearchResults search(SearchRequest request)

--- a/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
+++ b/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
@@ -78,7 +78,7 @@ public interface FindexNativeWrapper extends Library {
             throws CloudproofException;
     }
 
-    int h_upsert(byte[] newKeywordsBufferPtr,
+    int h_upsert(Pointer newKeywordsBufferPtr,
                  IntByReference newKeywordsBufferLen,
                  Pointer masterKeyPtr,
                  int masterKeyLen,
@@ -125,7 +125,7 @@ public interface FindexNativeWrapper extends Library {
                        String keywords,
                        String baseUrl);
 
-    int h_upsert_cloud(byte[] newKeywordsBufferPtr,
+    int h_upsert_cloud(Pointer newKeywordsBufferPtr,
                        IntByReference newKeywordsBufferLen,
                        String token,
                        Pointer labelPtr,

--- a/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
+++ b/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
@@ -105,7 +105,7 @@ public interface FindexNativeWrapper extends Library {
                   UpdateLinesCallback updateLines,
                   ListRemovedLocationsCallback listRemovedLocations);
 
-    int h_search(byte[] searchresultsPtr,
+    int h_search(Pointer searchresultsPtr,
                  IntByReference searchresultsLen,
                  Pointer masterKeyPtr,
                  int masterKeyLength,
@@ -117,7 +117,7 @@ public interface FindexNativeWrapper extends Library {
                  FetchEntryCallback fetchEntry,
                  FetchChainCallback fetchChain);
 
-    int h_search_cloud(byte[] dbUidsPtr,
+    int h_search_cloud(Pointer dbUidsPtr,
                        IntByReference dbUidsLen,
                        String token,
                        Pointer labelPtr,
@@ -135,7 +135,7 @@ public interface FindexNativeWrapper extends Library {
                        String baseUrl);
 
 
-    int h_generate_new_token(byte[] tokenPtr,
+    int h_generate_new_token(Pointer tokenPtr,
         IntByReference tokenLen,
         String indexIdPtr,
         Pointer fetchEntriesSeedPtr,

--- a/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
+++ b/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
@@ -78,7 +78,8 @@ public interface FindexNativeWrapper extends Library {
             throws CloudproofException;
     }
 
-    int h_upsert(
+    int h_upsert(byte[] newKeywordsBufferPtr,
+                 IntByReference newKeywordsBufferLen,
                  Pointer masterKeyPtr,
                  int masterKeyLen,
                  Pointer labelPtr,

--- a/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
+++ b/src/main/java/com/cosmian/jna/findex/ffi/FindexNativeWrapper.java
@@ -125,7 +125,9 @@ public interface FindexNativeWrapper extends Library {
                        String keywords,
                        String baseUrl);
 
-    int h_upsert_cloud(String token,
+    int h_upsert_cloud(byte[] newKeywordsBufferPtr,
+                       IntByReference newKeywordsBufferLen,
+                       String token,
                        Pointer labelPtr,
                        int labelLen,
                        String additions,

--- a/src/main/java/com/cosmian/jna/findex/ffi/UpsertResults.java
+++ b/src/main/java/com/cosmian/jna/findex/ffi/UpsertResults.java
@@ -1,0 +1,52 @@
+package com.cosmian.jna.findex.ffi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.Set;
+import com.cosmian.jna.findex.serde.Leb128Serializable;
+import com.cosmian.jna.findex.structs.Keyword;
+import com.cosmian.utils.CloudproofException;
+import com.cosmian.utils.Leb128;
+
+public class UpsertResults implements Leb128Serializable {
+
+    private Set<Keyword> results;
+
+    public UpsertResults() {
+        this.results = new HashSet<>();
+    }
+
+    public Set<Keyword> getResults() {
+        return results;
+    }
+
+    public boolean isEmpty() {
+        return results.isEmpty();
+    }
+
+    public int numberOfKeywords() {
+        return results.size();
+    }
+
+    @Override
+    public void readObject(InputStream is) throws CloudproofException {
+        try {
+
+            int setLen = (int) Leb128.readU64(is);
+            for (int i = 0; i < setLen; i++) {
+                Keyword keyword = new Keyword(Leb128.readByteArray(is));
+                results.add(keyword);
+            }
+        } catch (IOException e) {
+            throw new CloudproofException("failed deserializing the upsert results: " + e.getMessage(), e);
+        }
+
+    }
+
+    @Override
+    public void writeObject(OutputStream os) throws CloudproofException {
+        throw new CloudproofException("Upsert results are not serializable");
+    }
+}

--- a/src/test/java/com/cosmian/findex/TestFindexCloud.java
+++ b/src/test/java/com/cosmian/findex/TestFindexCloud.java
@@ -9,58 +9,61 @@ import org.junit.jupiter.api.Test;
 
 import com.cosmian.jna.findex.FindexCloud;
 import com.cosmian.jna.findex.ffi.SearchResults;
+import com.cosmian.jna.findex.ffi.UpsertResults;
 import com.cosmian.jna.findex.structs.Location;
 import com.cosmian.utils.RestClient;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class TestFindexCloud {
-    @Test
-    public void testFindexCloud() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        String baseUrl = System.getenv("COSMIAN_FINDEX_CLOUD_BASE_URL");
-        if (baseUrl == null) {
-            System.out.println("No COSMIAN_FINDEX_CLOUD_BASE_URL: ignoring");
-            return;
-        }
+/*public class TestFindexCloud {*/
+    /*@Test*/
+    /*public void testFindexCloud() throws Exception {*/
+        /*ObjectMapper mapper = new ObjectMapper();*/
+        /*mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);*/
+        /*String baseUrl = System.getenv("COSMIAN_FINDEX_CLOUD_BASE_URL");*/
+        /*if (baseUrl == null) {*/
+            /*System.out.println("No COSMIAN_FINDEX_CLOUD_BASE_URL: ignoring");*/
+            /*return;*/
+        /*}*/
 
-        String label = "Hello World!";
+        /*String label = "Hello World!";*/
 
-        RestClient client = new RestClient(baseUrl, Optional.empty());
-        String response = client.json_post("/indexes", "{ \"name\": \"Test\" }");
+        /*RestClient client = new RestClient(baseUrl, Optional.empty());*/
+        /*String response = client.json_post("/indexes", "{ \"name\": \"Test\" }");*/
 
-        Index index =  mapper.readValue(response, Index.class);
+        /*Index index =  mapper.readValue(response, Index.class);*/
 
-        String token = FindexCloud.generateNewToken(index.publicId, index.fetchEntriesKey, index.fetchChainsKey, index.upsertEntriesKey, index.insertChainsKey);
+        /*String token = FindexCloud.generateNewToken(index.publicId, index.fetchEntriesKey, index.fetchChainsKey, index.upsertEntriesKey, index.insertChainsKey);*/
 
-        FindexCloud.IndexRequest indexRequest = new FindexCloud.IndexRequest(token, label)
-            .add(new Location(1337), new String[] { "John", "Doe" })
-            .add(new Location(42), new String[] { "Jane", "Doe" });
+        /*FindexCloud.IndexRequest indexRequest = new FindexCloud.IndexRequest(token, label)*/
+            /*.add(new Location(1337), new String[] { "John", "Doe" })*/
+            /*.add(new Location(42), new String[] { "Jane", "Doe" });*/
 
-        FindexCloud.upsert(indexRequest);
+        /*UpsertResults res = FindexCloud.upsert(indexRequest);*/
+        /*assertEquals(0, res.getResults().size(), "wrong number of new keywords returned");*/
+        /*assertEquals(1, res.getResults().size(), "wrong number of new keywords returned");*/
 
-        FindexCloud.SearchRequest searchRequest = new FindexCloud.SearchRequest(token, label)
-            .keywords(new String[] { "Doe" });
+        /*FindexCloud.SearchRequest searchRequest = new FindexCloud.SearchRequest(token, label)*/
+            /*.keywords(new String[] { "Doe" });*/
 
-        SearchResults searchResults = FindexCloud.search(searchRequest);
+        /*SearchResults searchResults = FindexCloud.search(searchRequest);*/
 
-        assertEquals(new HashSet<>(Arrays.asList(new Long(1337), new Long(42))), searchResults.getNumbers());
-    }
+        /*assertEquals(new HashSet<>(Arrays.asList(new Long(1337), new Long(42))), searchResults.getNumbers());*/
+    /*}*/
 
-    public static class Index {
-        @JsonProperty(value = "public_id")
-        String publicId;
-        @JsonProperty(value = "fetch_entries_key")
-        byte[] fetchEntriesKey;
-        @JsonProperty(value = "fetch_chains_key")
-        byte[] fetchChainsKey;
-        @JsonProperty(value = "upsert_entries_key")
-        byte[] upsertEntriesKey;
-        @JsonProperty(value = "insert_chains_key")
-        byte[] insertChainsKey;
+    /*public static class Index {*/
+        /*@JsonProperty(value = "public_id")*/
+        /*String publicId;*/
+        /*@JsonProperty(value = "fetch_entries_key")*/
+        /*byte[] fetchEntriesKey;*/
+        /*@JsonProperty(value = "fetch_chains_key")*/
+        /*byte[] fetchChainsKey;*/
+        /*@JsonProperty(value = "upsert_entries_key")*/
+        /*byte[] upsertEntriesKey;*/
+        /*@JsonProperty(value = "insert_chains_key")*/
+        /*byte[] insertChainsKey;*/
 
-        Index() {}
-    }
-}
+        /*Index() {}*/
+    /*}*/
+/*}*/

--- a/src/test/java/com/cosmian/findex/TestFindexCloud.java
+++ b/src/test/java/com/cosmian/findex/TestFindexCloud.java
@@ -16,54 +16,53 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/*public class TestFindexCloud {*/
-    /*@Test*/
-    /*public void testFindexCloud() throws Exception {*/
-        /*ObjectMapper mapper = new ObjectMapper();*/
-        /*mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);*/
-        /*String baseUrl = System.getenv("COSMIAN_FINDEX_CLOUD_BASE_URL");*/
-        /*if (baseUrl == null) {*/
-            /*System.out.println("No COSMIAN_FINDEX_CLOUD_BASE_URL: ignoring");*/
-            /*return;*/
-        /*}*/
+public class TestFindexCloud {
+    @Test
+    public void testFindexCloud() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String baseUrl = System.getenv("COSMIAN_FINDEX_CLOUD_BASE_URL");
+        if (baseUrl == null) {
+            System.out.println("No COSMIAN_FINDEX_CLOUD_BASE_URL: ignoring");
+            return;
+        }
 
-        /*String label = "Hello World!";*/
+        String label = "Hello World!";
 
-        /*RestClient client = new RestClient(baseUrl, Optional.empty());*/
-        /*String response = client.json_post("/indexes", "{ \"name\": \"Test\" }");*/
+        RestClient client = new RestClient(baseUrl, Optional.empty());
+        String response = client.json_post("/indexes", "{ \"name\": \"Test\" }");
 
-        /*Index index =  mapper.readValue(response, Index.class);*/
+        Index index =  mapper.readValue(response, Index.class);
 
-        /*String token = FindexCloud.generateNewToken(index.publicId, index.fetchEntriesKey, index.fetchChainsKey, index.upsertEntriesKey, index.insertChainsKey);*/
+        String token = FindexCloud.generateNewToken(index.publicId, index.fetchEntriesKey, index.fetchChainsKey, index.upsertEntriesKey, index.insertChainsKey);
 
-        /*FindexCloud.IndexRequest indexRequest = new FindexCloud.IndexRequest(token, label)*/
-            /*.add(new Location(1337), new String[] { "John", "Doe" })*/
-            /*.add(new Location(42), new String[] { "Jane", "Doe" });*/
+        FindexCloud.IndexRequest indexRequest = new FindexCloud.IndexRequest(token, label)
+            .add(new Location(1337), new String[] { "John", "Doe" })
+            .add(new Location(42), new String[] { "Jane", "Doe" });
 
-        /*UpsertResults res = FindexCloud.upsert(indexRequest);*/
-        /*assertEquals(0, res.getResults().size(), "wrong number of new keywords returned");*/
-        /*assertEquals(1, res.getResults().size(), "wrong number of new keywords returned");*/
+        UpsertResults res = FindexCloud.upsert(indexRequest);
+        assertEquals(3, res.getResults().size(), "wrong number of new keywords returned");
 
-        /*FindexCloud.SearchRequest searchRequest = new FindexCloud.SearchRequest(token, label)*/
-            /*.keywords(new String[] { "Doe" });*/
+        FindexCloud.SearchRequest searchRequest = new FindexCloud.SearchRequest(token, label)
+            .keywords(new String[] { "Doe" });
 
-        /*SearchResults searchResults = FindexCloud.search(searchRequest);*/
+        SearchResults searchResults = FindexCloud.search(searchRequest);
 
-        /*assertEquals(new HashSet<>(Arrays.asList(new Long(1337), new Long(42))), searchResults.getNumbers());*/
-    /*}*/
+        assertEquals(new HashSet<>(Arrays.asList(new Long(1337), new Long(42))), searchResults.getNumbers());
+    }
 
-    /*public static class Index {*/
-        /*@JsonProperty(value = "public_id")*/
-        /*String publicId;*/
-        /*@JsonProperty(value = "fetch_entries_key")*/
-        /*byte[] fetchEntriesKey;*/
-        /*@JsonProperty(value = "fetch_chains_key")*/
-        /*byte[] fetchChainsKey;*/
-        /*@JsonProperty(value = "upsert_entries_key")*/
-        /*byte[] upsertEntriesKey;*/
-        /*@JsonProperty(value = "insert_chains_key")*/
-        /*byte[] insertChainsKey;*/
+    public static class Index {
+        @JsonProperty(value = "public_id")
+        String publicId;
+        @JsonProperty(value = "fetch_entries_key")
+        byte[] fetchEntriesKey;
+        @JsonProperty(value = "fetch_chains_key")
+        byte[] fetchChainsKey;
+        @JsonProperty(value = "upsert_entries_key")
+        byte[] upsertEntriesKey;
+        @JsonProperty(value = "insert_chains_key")
+        byte[] insertChainsKey;
 
-        /*Index() {}*/
-    /*}*/
-/*}*/
+        Index() {}
+    }
+}

--- a/src/test/java/com/cosmian/findex/TestRedis.java
+++ b/src/test/java/com/cosmian/findex/TestRedis.java
@@ -19,6 +19,7 @@ import com.cosmian.jna.findex.ffi.ProgressResults;
 import com.cosmian.jna.findex.structs.IndexedValue;
 import com.cosmian.jna.findex.ffi.SearchResults;
 import com.cosmian.jna.findex.structs.Keyword;
+import com.cosmian.jna.findex.structs.Location;
 import com.cosmian.jna.findex.structs.NextKeyword;
 import com.cosmian.utils.CloudproofException;
 
@@ -82,6 +83,20 @@ public class TestRedis {
                 .println("After insertion: entry_table size: " + db.getAllKeys(Redis.ENTRY_TABLE_INDEX).size());
             System.out
                 .println("After insertion: chain_table size: " + db.getAllKeys(Redis.CHAIN_TABLE_INDEX).size());
+
+            //
+            // Upsert a new keyword
+            //
+            HashMap<IndexedValue, Set<Keyword>> newIndexedKeyword = new HashMap<>();
+            Set<Keyword> expectdeKeywords = new HashSet<>();
+            expectdeKeywords.add(new Keyword("test"));
+            newIndexedKeyword.put(new IndexedValue(new Location("ici")), expectdeKeywords);
+            // It is returned the first time it is added.
+            Set<Keyword> newKeywords = Findex.upsert(new Findex.IndexRequest(key, label, db).add(newIndexedKeyword)).getResults();
+            assertEquals(expectdeKeywords, newKeywords, "new keyword is not returned");
+            // It is *not* returned the second time it is added.
+            newKeywords = Findex.upsert(new Findex.IndexRequest(key, label, db).add(newIndexedKeyword)).getResults();
+            assert(newKeywords.isEmpty());
 
             //
             // Search

--- a/src/test/java/com/cosmian/findex/TestRedis.java
+++ b/src/test/java/com/cosmian/findex/TestRedis.java
@@ -18,6 +18,7 @@ import com.cosmian.jna.findex.ffi.FindexUserCallbacks.SearchProgress;
 import com.cosmian.jna.findex.ffi.ProgressResults;
 import com.cosmian.jna.findex.structs.IndexedValue;
 import com.cosmian.jna.findex.ffi.SearchResults;
+import com.cosmian.jna.findex.ffi.UpsertResults;
 import com.cosmian.jna.findex.structs.Keyword;
 import com.cosmian.jna.findex.structs.Location;
 import com.cosmian.jna.findex.structs.NextKeyword;
@@ -78,7 +79,8 @@ public class TestRedis {
             // Upsert
             //
             Map<IndexedValue, Set<Keyword>> indexedValuesAndWords = IndexUtils.index(testFindexDataset);
-            Findex.upsert(new Findex.IndexRequest(key, label, db).add(indexedValuesAndWords));
+            UpsertResults res = Findex.upsert(new Findex.IndexRequest(key, label, db).add(indexedValuesAndWords));
+            assertEquals(583, res.getResults().size(), "wrong number of new upserted keywords");
             System.out
                 .println("After insertion: entry_table size: " + db.getAllKeys(Redis.ENTRY_TABLE_INDEX).size());
             System.out

--- a/src/test/java/com/cosmian/findex/TestSqlite.java
+++ b/src/test/java/com/cosmian/findex/TestSqlite.java
@@ -138,6 +138,20 @@ public class TestSqlite {
                 .println("After insertion: chain_table size: " + db.getAllKeyValueItems("chain_table").size());
 
             //
+            // Upsert a new keyword
+            //
+            HashMap<IndexedValue, Set<Keyword>> newIndexedKeyword = new HashMap<>();
+            Set<Keyword> expectdeKeywords = new HashSet<>();
+            expectdeKeywords.add(new Keyword("test"));
+            newIndexedKeyword.put(new IndexedValue(new Location(new Long(1))), expectdeKeywords);
+            // It is returned the first time it is added.
+            Set<Keyword> newKeywords = Findex.upsert(new Findex.IndexRequest(key, label, db).add(newIndexedKeyword)).getResults();
+            assertEquals(expectdeKeywords, newKeywords, "new keyword is not returned");
+            // It is *not* returned the second time it is added.
+            newKeywords = Findex.upsert(new Findex.IndexRequest(key, label, db).add(newIndexedKeyword)).getResults();
+            assert(newKeywords.isEmpty());
+
+            //
             // Search
             //
             System.out.println("");

--- a/src/test/java/com/cosmian/findex/TestSqlite.java
+++ b/src/test/java/com/cosmian/findex/TestSqlite.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import com.cosmian.TestUtils;
 import com.cosmian.jna.findex.Findex;
 import com.cosmian.jna.findex.ffi.SearchResults;
+import com.cosmian.jna.findex.ffi.UpsertResults;
 import com.cosmian.jna.findex.structs.IndexedValue;
 import com.cosmian.jna.findex.structs.Keyword;
 import com.cosmian.jna.findex.structs.Location;
@@ -131,7 +132,9 @@ public class TestSqlite {
             // Upsert
             //
             Map<IndexedValue, Set<Keyword>> indexedValuesAndWords = IndexUtils.index(testFindexDataset);
-            Findex.upsert(new Findex.IndexRequest(key, label, db).add(indexedValuesAndWords));
+            UpsertResults res = Findex.upsert(new Findex.IndexRequest(key, label, db).add(indexedValuesAndWords));
+            assertEquals(583, res.getResults().size(), "wrong number of new upserted keywords");
+            System.out.println("Upserted " + res.getResults().size() + " new keywords.");
             System.out
                 .println("After insertion: entry_table size: " + db.getAllKeyValueItems("entry_table").size());
             System.out


### PR DESCRIPTION
In order to avoid allocating an upper bound on the amount of memory needed in the FFI caller, I propose the following workaround:
1. the caller allocates the size of a pointer
2. Rust sets the value of this pointer to a pointer to the allocated buffer
3. Rust *forgets* about the buffer (avoids freeing the memory pointer to by the returned pointer)
4. the caller unwraps the pointer and copies the bytes to a proper structure
5. the caller free the pointer

This MR applies this method to the FFI API of Findex upsert. The Rust implementation can be found in the [Rust](https://github.com/Cosmian/cloudproof_rust/pull/40) repository. All tests pass on my machine.

I need particular proofreading on the free step (5) and potential incompatibilities with a Flutter/C implementation.
